### PR TITLE
Abort script run when the error occurs

### DIFF
--- a/lib/script/engine.rb
+++ b/lib/script/engine.rb
@@ -16,6 +16,13 @@ class Script::Engine
       puts Script::Output.started(step)
       step.run
       puts Script::Output.result(step)
+
+      abort_run if step.result == :failed
     end
+  end
+
+  def abort_run
+    # TODO: Print the result per steps table
+    abort
   end
 end


### PR DESCRIPTION
The script engine does not continue execution when one of the steps errors.

This could be handled with different strategies, but for now this is the default.