### PR TITLE
Pass hash of shareables to each step

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    script (0.0.2)
+    script (0.0.3)
       colorize
 
 GEM

--- a/lib/script/engine.rb
+++ b/lib/script/engine.rb
@@ -1,6 +1,7 @@
 class Script::Engine
   def initialize
     @steps = []
+    @shareables = {}
   end
 
   def steps
@@ -14,7 +15,7 @@ class Script::Engine
   def run
     @steps.each do |step|
       puts Script::Output.started(step)
-      step.run
+      step.run(@shareables)
       puts Script::Output.result(step)
 
       abort_run if step.result == :failed

--- a/lib/script/step.rb
+++ b/lib/script/step.rb
@@ -4,8 +4,8 @@ class Script::Step
     @block = block
   end
 
-  def run
-    @block.call
+  def run(shareables)
+    @block.call(shareables)
     @result = :succeded
   rescue
     @result = :failed


### PR DESCRIPTION
This makes you able to share data between steps like:

```ruby
script.step("Setup") do |shareables|
  shareables["environment"] = "staging"
end

script.step("Deploy to Kubernetes") do |shareables|
  deploy(shareables["environment"])
end
```